### PR TITLE
Fix automata iterator

### DIFF
--- a/src/main/java/lkh/modelchecker/ModelChecker.java
+++ b/src/main/java/lkh/modelchecker/ModelChecker.java
@@ -95,7 +95,6 @@ public class ModelChecker<State, Action> {
   private DeterministicAutomaton<Integer, Action> khAutomaton(Expression initExpr, Expression endExpr) {
     DeterministicAutomaton<Integer, Action> khAutomaton = AutomataOperations.intersection(cond1(initExpr), cond2(initExpr, endExpr));
     DotWriter.writeDFA(khAutomaton, "khAutomaton" + (minimize ? "_min" : "") + ".dot");
-    System.out.println("Minimize is set to " + minimize);
     return khAutomaton;
   }
 

--- a/src/main/java/lkh/pddl/PDDL.java
+++ b/src/main/java/lkh/pddl/PDDL.java
@@ -2,6 +2,7 @@ package lkh.pddl;
 
 import fr.uga.pddl4j.parser.DefaultParsedProblem;
 import fr.uga.pddl4j.parser.Parser;
+import fr.uga.pddl4j.planners.LogLevel;
 import fr.uga.pddl4j.problem.DefaultProblem;
 import fr.uga.pddl4j.problem.Fluent;
 import fr.uga.pddl4j.problem.Problem;
@@ -21,6 +22,7 @@ public class PDDL {
 
   public PDDL(String domainFilename, String problemFilename) throws FileNotFoundException {
     Parser parser = new Parser();
+    parser.setLogLevel(LogLevel.OFF);
     DefaultParsedProblem parsedProblem = parser.parse(domainFilename, problemFilename);
     problem = new DefaultProblem(parsedProblem);
     problem.instantiate();

--- a/src/test/java/lkh/automata/AutomataIteratorTest.java
+++ b/src/test/java/lkh/automata/AutomataIteratorTest.java
@@ -43,12 +43,6 @@ class AutomataIteratorTest {
     assertEquals(List.of('a', 'c'), nextString);
     assertTrue(automaton.evaluate(nextString));
 
-    assertTrue(iterator.hasNext());
-    nextString = iterator.next();
-    assertNotNull(nextString);
-    assertEquals(List.of('b', 'b'), nextString);
-    assertTrue(automaton.evaluate(nextString));
-
     assertFalse(iterator.hasNext()); // No more accepted strings within the limit
   }
 
@@ -71,11 +65,11 @@ class AutomataIteratorTest {
     Set<List<Character>> collectedStrings = new HashSet<>();
     iterator.forEachRemaining(collectedStrings::add);
 
-    assertEquals(6, collectedStrings.size());
+    assertEquals(4, collectedStrings.size());
     Set<List<Character>> expectedStrings = Set.of(
         List.of('b'),
-        List.of('a', 'c'), List.of('b', 'b'),
-        List.of('a', 'c', 'b'), List.of('b', 'a', 'c'), List.of('b', 'b', 'b')
+        List.of('a', 'c'),
+        List.of('a', 'c', 'b'), List.of('b', 'a', 'c')
     );
     assertEquals(expectedStrings, collectedStrings);
   }

--- a/src/test/java/lkh/modelchecker/ModelCheckerKhTest.java
+++ b/src/test/java/lkh/modelchecker/ModelCheckerKhTest.java
@@ -1,6 +1,6 @@
 package lkh.modelchecker;
 
-import lkh.automata.AutomataIterator;
+import lkh.dot.DotWriter;
 import lkh.expression.Expression;
 import lkh.expression.parser.ParseException;
 import lkh.lts.HashMapLTS;
@@ -55,22 +55,22 @@ public class ModelCheckerKhTest {
 
   @ParameterizedTest
   @MethodSource({"witnessesTestProvider"})
-  void testWitnesses(String initExprString, String endExprString, int witnessLengthLimit, Set<List<Character>> witnesses) throws ParseException {
+  void testWitnesses(String initExprString, String endExprString, int witnessLengthLimit, Set<List<Character>> expectedWitnesses) throws ParseException {
     Expression initExpr = Expression.of(initExprString);
     Expression endExpr = Expression.of(endExprString);
 
     Iterator<List<Character>> it = modelChecker.witnesses(initExpr, endExpr, witnessLengthLimit);
-    Set<List<Character>> expectedWitnesses = new HashSet<>();
-    it.forEachRemaining(expectedWitnesses::add);
+    Set<List<Character>> actualWitnesses = new HashSet<>();
+    it.forEachRemaining(actualWitnesses::add);
 
-    assertEquals(expectedWitnesses, witnesses);
+    assertEquals(expectedWitnesses, actualWitnesses);
   }
 
   private static Stream<Arguments> witnessesTestProvider() {
     return Stream.of(
         Arguments.of("p and q", "s or t", 3, Set.of(List.of('a', 'b'))),
         Arguments.of("p", "p", 3, Set.of(List.of())),
-        Arguments.of("q and r", "r", 6, Set.of(List.of(), List.of('c', 'b', 'a'), List.of('c', 'b', 'a', 'c', 'b', 'a')))
+        Arguments.of("q and r", "r", 6, Set.of(List.of()))
         //Arguments.of("u", "q")
     );
   }


### PR DESCRIPTION
The automata iterator, while trying to avoid cycles, was preventing some acyclic paths to be shown because some state in it was present in some previous path.

Modified it so that it checks that the next state is not present in the current path only.

Other changes:
- Removed the PDDL parser logging to remove the annoying PDDL output
- Fixed some tests